### PR TITLE
Install backtrader

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ ARG workdir=/app
 
 RUN mkdir $workdir
 WORKDIR $workdir
+ADD Pipfile $workdir
+ADD Pipfile.lock $workdir
 
 RUN pip install --upgrade pip && \
-    pip install pipenv
+    pip install pipenv && \
+    pipenv sync

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 build:
-	docker build -t doogwood008/backtrader .
+	docker build -t dogwood008/backtrader .
 
 run:
 	docker run --rm -it dogwood008/backtrader bash

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,13 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+backtrader = "*"
+
+[requires]
+python_version = "3.8"
+

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,28 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "62f2c898940a09cc88c8fc42c85e52c3526c851c12517325c638b20dfa1be2ab"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.8"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "backtrader": {
+            "hashes": [
+                "sha256:0dc8912a98352b75122f8d7084bc63ee47f61c2a1d16f506d4d82aee3941297a"
+            ],
+            "index": "pypi",
+            "version": "==1.9.76.123"
+        }
+    },
+    "develop": {}
+}


### PR DESCRIPTION
## Diff

- 🐳  `Dockerfile` にインストール処理追加
- ✏️  `Makefile` の typo 修正
- ➕  ライブラリ `backtrader` の追加

## Referred

以下、  [株のシステムトレードをしよう - 1から始める株自動取引システムの作り方](https://how-to-make-stock-trading-system.dogwood008.com/) より。

- [Pipenvのインストール：Pipenvによるパッケージのバージョン固定](https://how-to-make-stock-trading-system.dogwood008.com/entry/install-pipenv)
- [Pipenv を使って backtrader をインストールする：コンテナの中でインストール編](https://how-to-make-stock-trading-system.dogwood008.com/entry/install-backtrader-in-container)
- [Pipenv を使って backtrader をインストールする：イメージのビルドの段階でインストール編](https://how-to-make-stock-trading-system.dogwood008.com/entry/install-backtrader-in-image)