### PR TITLE
手仕舞いできるようにする

### DIFF
--- a/src/basic_strategy.py
+++ b/src/basic_strategy.py
@@ -103,14 +103,27 @@ class BasicStrategy(bt.Strategy):
         '''終了時にはファイルをクローズする。Backtraderから呼ばれる。'''
         self.fhandler.close()
 
-    def _is_falling_over_5_ticks(self) -> bool:
+
+    def _is_increasing_over_n_ticks(self, n: int) -> bool:
+        '''
+        Returns
+        ---------------
+            もしn本連続で上がっているならTrue
+        '''
+        return all(map(
+            lambda x: self._dataclose[-x] >= self._dataclose[-(x+1)],
+            range(n)))
+
+    def _is_falling_over_n_ticks(self, n: int) -> bool:
         '''
         Returns
         --------------- 
-            もし5本連続で下がっているならTrue
+            もしn本連続で下がっているならTrue
         '''
-        return self._dataclose[0] < self._dataclose[-1] < \
-           self._dataclose[-2] < self._dataclose[-3] < self._dataclose[-4]
+        # <= だと、>=の時に同時に買い／売り注文を出してしまう
+        return all(map(
+            lambda x: self._dataclose[-x] < self._dataclose[-(x+1)],
+            range(n)))
 
     def _buy_sell_in_str(self, order: Order) -> str:
         '''

--- a/src/basic_strategy.py
+++ b/src/basic_strategy.py
@@ -36,6 +36,8 @@ class BasicStrategy(bt.Strategy):
         self._setup_logger(loglevel)
         self.sma = bt.indicators.SimpleMovingAverage(
             self.datas[0], period=self.params.smaperiod)
+        self._cash = 0
+        self._value = 0
 
 
     def notify_order(self, order: Order) -> None:
@@ -69,6 +71,18 @@ class BasicStrategy(bt.Strategy):
                  executed.price, executed.size))
             # 注文が通らなかった
             import pdb; pdb.set_trace()  # FIXME: WIP
+    def notify_cashvalue(self, cash: float, value: float):
+        '''
+        Parameters
+        --------------
+        cash: float
+            現金
+        value: float
+            時価総額
+        '''
+        self._debug(f'notify_cashvalue(cash={cash:9,} / value={value:9,})')
+        [self._cash, self._value] = cash, value
+        return
 
     def next(self):
         self.p.tick_counter += 1

--- a/src/basic_strategy.py
+++ b/src/basic_strategy.py
@@ -133,13 +133,6 @@ class BasicStrategy(bt.Strategy):
         '''
         return OrderBase.OrdTypes[order.ordtype]
 
-        # if order.isbuy():
-        #     return 'buy'
-        # elif order.issell():
-        #     return 'sell'
-        # else:
-        #     raise 'Unknown type'
-
     def _status_in_str(self, order: Order) -> str:
         '''
         Returns

--- a/src/basic_strategy.py
+++ b/src/basic_strategy.py
@@ -53,24 +53,20 @@ class BasicStrategy(bt.Strategy):
         - Rejected: Rejected by the broker
         '''
         # https://www.backtrader.com/docu/order/#:~:text=of%20an%20order-,Order%20Status%20values,-The%20following%20are
-        if order.status == Order.Accepted:
-            # Brokerが注文受領
-            self._debug('Accepted: [%s] %.2f * %d' %
-                (self._buy_sell_in_str(order),
-                 order.price or 0, order.size or 0))
-        elif order.status == Order.Completed:
+        if order.status == Order.Completed:
             # 注文が通った
             executed = order.executed
-            self._info('Completed: [%s]: %.2f * %d' %
-                (self._buy_sell_in_str(order),
+            self._info('%9s: [%s]: %.2f * %d' %
+                (self._status_in_str(order),
+                 self._buy_sell_in_str(order),
                  executed.price, executed.size))
-        elif order.status in \
-            (Order.Canceled, Order.Expired, Order.Margin, Order.Rejected):
-            self._debug('Completed: [%s]: %.2f * %d' %
-                (self._buy_sell_in_str(order),
-                 executed.price, executed.size))
-            # 注文が通らなかった
-            import pdb; pdb.set_trace()  # FIXME: WIP
+        else:
+            # 注文が通らなかった 他
+            self._debug('%9s: [%s]: %.2f * %d' %
+                (self._status_in_str(order),
+                 self._buy_sell_in_str(order),
+                 order.price or 0, order.size or 0))
+
     def notify_cashvalue(self, cash: float, value: float):
         '''
         Parameters

--- a/src/basic_strategy.py
+++ b/src/basic_strategy.py
@@ -22,7 +22,7 @@ class BasicStrategy(bt.Strategy):
         # https://github.com/mementum/backtrader/blob/e2674b1690f6366e08646d8cfd44af7bb71b3970/backtrader/linebuffer.py#L386-L388
         dt = dt or self.datas[0].datetime.datetime(
             ago=0, tz=pytz.timezone('Asia/Tokyo'))
-        self._logger.log(loglevel, '%s, %s' % (dt.isoformat(), txt))
+        self._logger.log(loglevel, '%s [%6d], %s' % (dt.isoformat(), self.p.tick_counter, txt))
 
     def _debug(self, txt, dt=None):
         self._log(txt, DEBUG, dt)
@@ -136,7 +136,7 @@ class BasicStrategy(bt.Strategy):
         return OrderBase.Status[order.status]
 
     def _setup_logger(self, loglevel):
-        formatter = Formatter('[%(levelname)s] %(message)s')
+        formatter = Formatter('[%(levelname)5s] %(message)s')
         self._logger = getLogger(__name__)
         self.handler = StreamHandler()
         self.handler.setLevel(loglevel)

--- a/src/main.py
+++ b/src/main.py
@@ -55,7 +55,10 @@ if __name__ == '__main__':
     cerebro.adddata(data)
 
     # Set our desired cash start
-    cerebro.broker.setcash(100000.0)
+    cerebro.broker.setcash(1000.0 * 10000)
+
+    # https://www.backtrader.com/blog/posts/2016-12-06-shorting-cash/shorting-cash/
+    # cerebro.broker.set_shortcash(False)
 
     # Print out the starting conditions
     print('Starting Portfolio Value: %.2f' % cerebro.broker.getvalue())


### PR DESCRIPTION
## 変更点

- ✨  手仕舞いできるようにする
  - 建玉を参照し、反対売買かつ同一数量となるように注文を出す
- ♻️ リファクタ